### PR TITLE
fix: urls

### DIFF
--- a/config/docusaurus/index.json
+++ b/config/docusaurus/index.json
@@ -10,7 +10,7 @@
     {
       "label": "Portkey GitHub",
       "link": "external",
-      "externalLink": "https://github.com/baijianxiong15966620168/tina-docs",
+      "externalLink": "https://github.com/Portkey-Wallet",
       "position": "right"
     }
   ],
@@ -20,5 +20,5 @@
     "darkSrc": "/img/portkey-logo-dark.png"
   },
   "title": "Portkey Docs",
-  "url": "https://tinasaurus.vercel.app/"
+  "url": "https://doc.portkey.finance/"
 }


### PR DESCRIPTION
- The github link on the top right should link to the Portkey official github
- The url of the site should be doc.portkey.finance